### PR TITLE
✅ tests - fix JUnit 4/5 for IntelliJ

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <developerConnection>scm:git:ssh://github.com/graybytes/module-maven-plugin.git</developerConnection>
     <url>https://github.com/graybytes/module-maven-plugin/tree/master</url>
    </scm>
-    
+
     <distributionManagement>
      <snapshotRepository>
 	   <id>ossrh</id>
@@ -37,14 +37,14 @@
       <id>ossrh</id>
       <name>Central Repository OSSRH</name>
       <url>https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/</url>
-    </repository>  
+    </repository>
   </distributionManagement>
-    
+
     <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>${maven.compiler.source}</maven.compiler.target>
-    <junit.jupiter.version>5.6.0</junit.jupiter.version>
+    <junit.jupiter.version>5.8.1</junit.jupiter.version>
     <junit.platform.version>1.5.2</junit.platform.version>
         <maven.version>3.3.9</maven.version>
     </properties>
@@ -87,7 +87,7 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.12</version>
+            <version>4.13.1</version>
             <scope>test</scope>
         </dependency>
 
@@ -99,26 +99,17 @@
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-api</artifactId>
-            <version>${junit.jupiter.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
-            <version>${junit.jupiter.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.junit.platform</groupId>
-            <artifactId>junit-platform-runner</artifactId>
-            <version>${junit.platform.version}</version>
+            <artifactId>junit-platform-launcher</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.junit.vintage</groupId>
             <artifactId>junit-vintage-engine</artifactId>
-            <version>5.6.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -133,6 +124,17 @@
         </dependency>
 
     </dependencies>
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.junit</groupId>
+                <artifactId>junit-bom</artifactId>
+                <version>${junit.jupiter.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
     <build>
         <plugins>
             <plugin>
@@ -196,7 +198,7 @@
 			    </configuration>
 		  </execution>
 	      </executions>
-	    </plugin>   
+	    </plugin>
 	</plugins>
     </build>
 </project>


### PR DESCRIPTION
This PR fixes the JUnit tests so they run in JetBrain's IntelliJ 2021.2.3. 

I followed the dependencies outlined in [JUnit's User Guide](https://junit.org/junit5/docs/current/user-guide/#migrating-from-junit4). Notice that versions are not needed on the junit dependencies since they are provided by the junit-bom.

![tests-pass](https://user-images.githubusercontent.com/392266/142137544-dade8935-939a-4757-b856-bb916468d358.png)


